### PR TITLE
añadir .gitignore a los directorios creados

### DIFF
--- a/fsmaker.php
+++ b/fsmaker.php
@@ -698,6 +698,7 @@ final class fsmaker
         ];
         foreach ($folders as $folder) {
             $this->createFolder($name . '/' . $folder);
+            file_put_contents($name . '/' . $folder . '/.gitignore', "*\n!.gitignore");
         }
 
         foreach (explode(',', self::TRANSLATIONS) as $filename) {


### PR DESCRIPTION
añadir .gitignore a los directorios creados para que al crear un repositorio git se conserve la estructura de directorios.