### PR TITLE
refactorizar para usar como un binario de composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,26 @@
 Herramienta de creación de plugin para FacturaScripts.
 - https://facturascripts.com/publicaciones/fsmaker-y-el-nuevo-curso-de-programacion
 
-# Instalar en Linux o macOS
-Ejecute estos comandos en el terminal del sistema (necesita tener git instalado en el sistema).
+# Requisitos
+- Instalar PHP 7.3 o superior.
+- En windows, añada el directorio donde se encuentre el ejecutable `php.exe` a su variable de entorno PATH, si todavía no lo ha hecho. ([Add PHP to Environment Variables](https://dinocajic.medium.com/add-xampp-php-to-environment-variables-in-windows-10-af20a765b0ce))
 
+# Instalación
+Clonar el respositorio en el directorio deseado.
 ```
 git clone https://github.com/FacturaScripts/fsmaker.git
-sudo ln -s $(pwd)/fsmaker/fsmaker.sh /usr/local/bin/fsmaker
+```
+## Instalar en Linux o macOS
+```
+sudo ln -s $(pwd)/fsmaker/fsmaker /usr/local/bin/fsmaker
+```
+```
 sudo chmod +x /usr/local/bin/fsmaker
 ```
 
-# Instalar en Windows
-- Instale PHP, si todavía no lo ha hecho.
-- Descargue desde https://github.com/FacturaScripts/fsmaker/archive/refs/heads/main.zip 
-- Añada la variable de entorno de windows PATH (del usuario o del sistema) el path/ruta donde esté instalado PHP
-- Añada la variable de entorno de windows PATH (del usuario o del sistema) el path/ruta donde esté instalado fsmaker 
-- Modifique fsmaker.bat para ...
-  + Cambie el path de la variable pathPHP por el path/ruta donde esté instalado PHP
-  + Cambie el path de la variable pathFSMAKER por el path/ruta donde esté instalado fsmaker
+## Instalar en Windows
+
+Añada el directorio donde se encuentre fsmaker a su variable de entorno PATH.
 
 ## Issues / Feedback
 https://facturascripts.com/contacto

--- a/fsmaker
+++ b/fsmaker
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 /**
  * @author Carlos García Gómez            <carlos@facturascripts.com>
@@ -5,7 +6,7 @@
  * @author Jerónimo Pedro Sánchez Manzano <socger@gmail.com>
  */
 if (php_sapi_name() !== 'cli') {
-    die("Usar: php fsmaker.php");
+    die("Usar: php fsmaker");
 }
 
 include __DIR__ . '/Columna.php';

--- a/fsmaker.bat
+++ b/fsmaker.bat
@@ -1,10 +1,2 @@
 @echo off 
-
-rem ... creamos las variables que usaremos como path para llamar a php y a fsmaker.php
-set pathPHP=C:\xampp\php
-set pathFSMAKER=E:\PROGRAMACION\PHP\FACTURASCRIPTS\fsmaker
-
-rem ... creamos la variable de entorno donde está este .bat para en futuras ocasiones poder llamar a este .bat sin necesidad de poner su path
-rem ... setx path "%path%;%pathFSMAKER%" ... no funciona bien ... no se queda guardado como variable de entorno después de ejecutar el .bat
-
-%pathPHP%\php %pathFSMAKER%\fsmaker.php %1
+php %~dp0/fsmaker %*

--- a/fsmaker.sh
+++ b/fsmaker.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env sh
-
-# gets the current file folder
-folder=$(dirname "$(readlink "$0")")
-
-# run the php script
-php "$folder"/fsmaker.php $@


### PR DESCRIPTION
Eliminamos extensión .php y añadimos shebang.
Eliminamos el script .sh
Modificamos el archivo fsmake.bat para que pueda usarse con el refactor.
Modificamos la documentación simplificando los pasos para la instalación.

He probado en Linux y en Windows, pero no lo he probado en Mac.

Siéntase libre de modificar e incluso descartar esta PR. Soy aficionado a la programación y me encanta aprender y contribuir al software libre.