### PR TITLE
fix .gitignore en carpetas vacias

### DIFF
--- a/fsmaker.php
+++ b/fsmaker.php
@@ -739,7 +739,7 @@ final class fsmaker
         ];
         foreach ($folders as $folder) {
             $this->createFolder($name . '/' . $folder);
-            file_put_contents($name . '/' . $folder . '/.gitignore', "*\n!.gitignore");
+            touch($name . '/' . $folder . '/.gitignore');
         }
 
         foreach (explode(',', self::TRANSLATIONS) as $filename) {


### PR DESCRIPTION
Corregimos la creación del archivo .gitignore en las carpetas vacias ya que como estaba antes excluia a los archivos internos de cada carpeta y no es correcto.

La finalidad de incluir el archivo .gitignore en las carpetas vacias es que se incluyan en el repositorio pero no tiene sentido que se excluyan los archivos que se encuentran en esas carpetas.

Fue un error mio al implementarlo.

gracias @daniel89fg por avisar. Saludos.