### PR TITLE
Actualizar y comentar ejemplos

### DIFF
--- a/SAMPLES/Controller.php.sample
+++ b/SAMPLES/Controller.php.sample
@@ -1,22 +1,42 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace FacturaScripts\[[NAME_SPACE]]\Controller;
 
 use FacturaScripts\Core\Base\Controller;
 
+/**
+ * Un controlador es básicamente una página o una opción del menú de FacturaScripts.
+ *
+ * https://facturascripts.com/publicaciones/los-controladores-410
+ */
 class [[NAME]] extends Controller
 {
     public function getPageData(): array
     {
-        $data = parent::getPageData();
-        $data["menu"] = "admin";
-        $data["title"] = "[[NAME]]";
-        $data["icon"] = "fas fa-file";
-        return $data;
+        $pageData = parent::getPageData();
+        $pageData["menu"] = "admin";
+        $pageData["title"] = "[[NAME]]";
+        $pageData["icon"] = "fas fa-file";
+        return $pageData;
     }
-    
-    public function privateCore(&$response, $user, $permissions)
+
+    /**
+     * Ejecuta la lógica privada del controlador.
+     */
+    public function privateCore(&$response, $user, $permissions): void
     {
         parent::privateCore($response, $user, $permissions);
+
+        // tu código aquí
+    }
+
+    /**
+     * Ejecuta la lógica pública del controlador.
+     */
+    public function publicCore(&$response): void
+    {
+        parent::publicCore($response);
+
         // tu código aquí
     }
 }

--- a/SAMPLES/Cron.php.sample
+++ b/SAMPLES/Cron.php.sample
@@ -1,17 +1,25 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace FacturaScripts\Plugins\[[NAME]];
 
-use FacturaScripts\Core\Base\CronClass;
+use FacturaScripts\Core\Template\CronClass;
 
+/**
+ * El cron de FacturaScripts ejecutará todos los procesos cron de los plugins activos,
+ * siempre y cuando haya sido configurado en el sistema o hosting.
+ * Así que si necesita ejecutar algo de forma periódica, el mejor lugar es el cron de su plugin.
+ *
+ * https://facturascripts.com/publicaciones/el-archivo-cron-php-855
+ */
 class Cron extends CronClass
 {
-    public function run()
+    public function run(): void
     {
         /*
-        if ($this->isTimeForJob("my-job-name", "6 hours")) {
-            // su código aquí
-            $this->jobDone("my-job-name");
-        }
+        $this->job('mi-trabajo')->everyDayAt(8)->run(function () {
+            // tu código aquí
+            // esto se ejecutará cada día a las 8h
+        });
         */
     }
 }

--- a/SAMPLES/EditController.php.sample
+++ b/SAMPLES/EditController.php.sample
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace FacturaScripts\[[NAME_SPACE]]\Controller;
 
 use FacturaScripts\Core\Lib\ExtendedController\EditController;
@@ -12,9 +13,9 @@ class Edit[[MODEL_NAME]] extends EditController
 
     public function getPageData(): array
     {
-        $data = parent::getPageData();
-        $data["title"] = "[[MODEL_NAME]]";
-        $data["icon"] = "fas fa-search";
-        return $data;
+        $pageData = parent::getPageData();
+        $pageData["title"] = "[[MODEL_NAME]]";
+        $pageData["icon"] = "fas fa-search";
+        return $pageData;
     }
 }

--- a/SAMPLES/ExtensionController.php.sample
+++ b/SAMPLES/ExtensionController.php.sample
@@ -1,8 +1,15 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace FacturaScripts\[[NAME_SPACE]]\Extension\Controller;
 
 use Closure;
 
+/**
+ * Para modificar el comportamiento o añadir pestañas o secciones a controladores de otros plugins (o del core)
+ * podemos crear una extensión de ese controlador.
+ *
+ * https://facturascripts.com/publicaciones/extensiones-de-modelos
+ */
 class [[NAME]]
 {
     public function createViews(): Closure

--- a/SAMPLES/ExtensionModel.php.sample
+++ b/SAMPLES/ExtensionModel.php.sample
@@ -1,8 +1,15 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace FacturaScripts\[[NAME_SPACE]]\Extension\Model;
 
 use Closure;
 
+/**
+ * Para modificar el comportamiento de modelos de otro plugins (o del core)
+ * podemos crear una extensión de ese modelo.
+ *
+ * https://facturascripts.com/publicaciones/extensiones-de-modelos
+ */
 class [[NAME]]
 {
     // Ejemplo para añadir un método ... añadir el método usado()

--- a/SAMPLES/Init.php.sample
+++ b/SAMPLES/Init.php.sample
@@ -1,17 +1,29 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace FacturaScripts\Plugins\[[NAME]];
 
 use FacturaScripts\Core\Base\InitClass;
 
+/**
+ * Los plugins pueden contener un archivo Init.php en el que se definen procesos a ejecutar
+ * cada vez que carga FacturaScripts o cuando se instala o actualiza el plugin.
+ *
+ * https://facturascripts.com/publicaciones/el-archivo-init-php-307
+ */
 class Init extends InitClass
 {
-    public function init()
+    public function init(): void
     {
         // se ejecuta cada vez que carga FacturaScripts (si este plugin está activado).
     }
 
-    public function update()
+    public function update(): void
     {
-        // se ejecuta cada vez que se instala o actualiza el plugin.
+        // se ejecuta cada vez que se instala o actualiza el plugin
+    }
+
+    public function uninstall(): void
+    {
+        // se ejecuta cada vez que se desinstale el plugin. Primero desinstala y luego ejecuta el uninstall.
     }
 }

--- a/SAMPLES/ListController.php.sample
+++ b/SAMPLES/ListController.php.sample
@@ -1,25 +1,33 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace FacturaScripts\[[NAME_SPACE]]\Controller;
 
 use FacturaScripts\Core\Lib\ExtendedController\ListController;
 
+/**
+ * Este es un controlador específico para listados. Permite una o varias pestañas.
+ * Cada una con un listado de los registros de un modelo.
+ * Además hace uso de archivos de XMLView para definir qué columnas mostrar y cómo.
+ *
+ * https://facturascripts.com/publicaciones/listcontroller-232
+ */
 class List[[MODEL_NAME]] extends ListController
 {
     public function getPageData(): array
     {
-        $data = parent::getPageData();
-        $data["title"] = "[[TITLE]]";
-        $data["menu"] = "[[MENU]]";
-        $data["icon"] = "fas fa-search";
-        return $data;
+        $pageData = parent::getPageData();
+        $pageData["title"] = "[[TITLE]]";
+        $pageData["menu"] = "[[MENU]]";
+        $pageData["icon"] = "fas fa-search";
+        return $pageData;
     }
 
-    protected function createViews()
+    protected function createViews(): void
     {
         $this->createViews[[MODEL_NAME]]();
     }
 
-    protected function createViews[[MODEL_NAME]](string $viewName = "List[[MODEL_NAME]]")
+    protected function createViews[[MODEL_NAME]](string $viewName = "List[[MODEL_NAME]]"): void
     {
         $this->addView($viewName, "[[MODEL_NAME]]", "[[TITLE]]");
         

--- a/SAMPLES/Test.php.sample
+++ b/SAMPLES/Test.php.sample
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace FacturaScripts\Test\Plugins;
 
 use FacturaScripts\Test\Traits\LogErrorsTrait;

--- a/SAMPLES/View.html.twig.sample
+++ b/SAMPLES/View.html.twig.sample
@@ -1,13 +1,33 @@
+{#
+FacturaScripts utiliza el motor de plantillas twig.
+Los archivos de las vistas HTML deben tener la extensión .html.twig
+y se deben almacenar en la carpeta View de su plugin.
+
+https://facturascripts.com/publicaciones/las-vistas-html-69
+
+https://twig.symfony.com/
+
+#}
+
 {% extends "Master/MenuTemplate.html.twig" %}
 
 {% block body %}
     {{ parent() }}
+
+    {# tu código aquí #}
+
 {% endblock %}
 
 {% block css %}
     {{ parent() }}
+
+    {# tu código aquí #}
+
 {% endblock %}
 
 {% block javascripts %}
     {{ parent() }}
+
+    {# tu código aquí #}
+
 {% endblock %}

--- a/SAMPLES/facturascripts.ini.sample
+++ b/SAMPLES/facturascripts.ini.sample
@@ -1,4 +1,9 @@
-description = '[[NAME]]'
-min_version = 2023.1
 name = '[[NAME]]'
+description = '[[NAME]]'
 version = 0.1
+min_version = 2023.1
+
+;Campos opcionales:
+;min_php = 7.3
+;require = 'POS'
+;require_php = 'soap'


### PR DESCRIPTION
- Se añade declare(strict_types=1); a los archivos .sample
- Se añaden comentarios que ayudan a entender el funcionamiento de los plugins y se incluye los enlaces a la documentación en cada clase de los archivos .sample
- Se actualizan ejemplos y metodos, según la documentación actualizada.