### PR TITLE
configurar como libreria composer con ejecutable bin/fsmaker

### DIFF
--- a/bin/fsmaker
+++ b/bin/fsmaker
@@ -1,0 +1,4 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+include $_composer_autoload_path ?? __DIR__ . '/../vendor/autoload.php';

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,24 @@
+{
+  "name": "facturascripts/fsmaker",
+  "description": "Herramienta de creación de plugin para FacturaScripts.",
+  "type": "project",
+  "license": "LGPL-3.0-or-later",
+  "authors": [
+    {
+      "name": "Carlos García Gómez",
+      "email": "carlos@facturascripts.com"
+    }
+  ],
+  "autoload": {
+    "psr-4": {
+      "Facturascripts\\Fsmaker\\": "src/"
+    },
+    "files": ["fsmaker.php"]
+  },
+  "minimum-stability": "stable",
+  "require": {
+    "php": ">=7.3"
+  },
+  "bin": ["bin/fsmaker"],
+  "version": "1.0.0"
+}

--- a/fsmaker.php
+++ b/fsmaker.php
@@ -9,6 +9,8 @@ if (php_sapi_name() !== 'cli') {
     die("Usar: php fsmaker.php");
 }
 
+$argv = $_SERVER['argv'] ?? [];
+
 include __DIR__ . '/Columna.php';
 
 final class fsmaker


### PR DESCRIPTION
Con estos cambios es posible manejar como una paquete de Composer con su ejecutable funcionando.

De esta forma se puede:
- Agregar librerías como [Laravel Prompts](https://laravel.com/docs/10.x/prompts)
- Registrar en https://packagist.org/ para después instalar`(composer global require facturascripts/fsmaker)` de forma global y poder ejecutar en cualquier directorio.
- Actualizar con solo ejecutar `(composer global update)`

Se ha respetado la retrocompatibilidad, por lo que se podría instalar de la forma sugerida (composer global) y sigue funcionando tambien de la forma de instalación documentada actualmente(ojo que no lo he probado en todos los sistemas, es necesario realizar varias pruebas en varios sistemas operativos).

También se puede instalar de en un proyecto de la forma habitual(pero recomiendo instalar globalmente):
`composer require facturascripts/fsmaker`
`cd Plugins`
`../vendor/bin/fsmaker`



Si queréis probar de forma local:
![imagen](https://github.com/FacturaScripts/fsmaker/assets/2836337/a143e28d-c301-41a2-9e23-bafe8261a139)
teneis que configurar el composer.json como en la imagen donde la "url" es el path donde hayas clonado fsmaker
despues composer install
os vais al directorio Plugins
y ejecutar `../vendor/bin/fsmaker`
