### PR TITLE
Copiar el plugin antes de ejecutar los tests

### DIFF
--- a/src/RunTests.php
+++ b/src/RunTests.php
@@ -65,6 +65,38 @@ class RunTests
             return;
         }
 
+        // Get Plugin Details
+        $currentPluginName = basename(getcwd());
+        $currentPluginPath = realpath(getcwd());
+        $rawFsPluginPath = $fs_folder . 'Plugins' . DIRECTORY_SEPARATOR . $currentPluginName;
+        $fsPluginPath = realpath($rawFsPluginPath);
+
+        // Implement Path Comparison Logic
+        echo "\n=== Sincronizando plugin con FacturaScripts en " . $fs_folder . "Plugins/ ===\n";
+        if ($fsPluginPath === false) {
+            // plugin does not exist in FacturaScripts Plugins directory
+            echo "   - Plugin '" . $currentPluginName . "' no encontrado en FacturaScripts. Copiando plugin completo a: " . $rawFsPluginPath . "\n";
+            self::copyDirectory($currentPluginPath, $rawFsPluginPath);
+        } else {
+            // plugin exists in FacturaScripts Plugins directory
+            if ($fsPluginPath !== $currentPluginPath) {
+                // plugin in FS is different from the current one
+                echo "   - Encontrada una versión diferente del plugin '" . $currentPluginName . "' en FacturaScripts. Reemplazando con la versión actual.\n";
+                echo "     - Eliminando contenido de: " . $fsPluginPath . "\n";
+                self::deleteDirectoryContents($fsPluginPath);
+                // Asegurarse de que el directorio base exista después de deleteDirectoryContents si este lo elimina
+                if (!is_dir($fsPluginPath)) {
+                    mkdir($fsPluginPath, 0777, true);
+                }
+                echo "     - Copiando plugin actual a: " . $fsPluginPath . "\n";
+                self::copyDirectory($currentPluginPath, $fsPluginPath);
+            } else {
+                // plugin in FS is the same as the current one
+                echo "   - El plugin '" . $currentPluginName . "' ya está en su sitio en FacturaScripts y es el que se está probando. No se necesita copiar.\n";
+            }
+        }
+        echo "=== Sincronización de plugin finalizada ===\n\n";
+
         echo "Buscando carpetas de tests dentro de 'Test/'...\n";
         $foundTests = false;
         // recorremos las carpetas dentro de Test


### PR DESCRIPTION
This commit refactors the `run-tests` command logic in `fsmaker` for improved efficiency and clarity.

Key changes:
- The plugin synchronization logic (checking the plugin's presence and version in `FacturaScripts/Plugins/` and copying/deleting as needed) has been moved from `RunTests::runFolder` to the main `RunTests::run` method.
- This ensures that the plugin synchronization occurs only *once* when `fsmaker run-tests` is executed, regardless of how many test subfolders (e.g., `Test/BasicTests`, `Test/ApiTests`) the plugin has. Previously, this logic was executed for each test subfolder.
- The `RunTests::runFolder` method is now streamlined to only handle the setup and execution of tests for its specific subfolder, i.e., copying test files from `MyPlugin/Test/<SubFolder>` to `FacturaScripts/Test/Plugins/` and then invoking phpunit.

This change improves performance by reducing redundant file operations and makes the code structure more logical, with `run` handling the global plugin environment and `runFolder` handling specific test suites.