### PR TITLE
implementar symfony console

### DIFF
--- a/bin/fsmaker
+++ b/bin/fsmaker
@@ -1,4 +1,13 @@
 #!/usr/bin/env php
 <?php declare(strict_types=1);
 
-include __DIR__ . '/../fsmaker.php';
+require __DIR__ . '/../vendor/autoload.php';
+
+use fsmaker\Console\ApplicationFS;
+use fsmaker\Console\Command\PluginCommand;
+
+$application = new ApplicationFS();
+
+$application->add(new PluginCommand());
+
+$application->run();

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
   },
   "minimum-stability": "stable",
   "require": {
-    "php": ">=8.0",
+    "php": ">=8.2",
+    "symfony/console": "^7.3",
     "ext-zip": "*",
     "ext-mbstring": "*",
     "ext-ctype": "*"

--- a/fsmaker.php
+++ b/fsmaker.php
@@ -543,7 +543,7 @@ final class fsmaker
         }
     }
 
-    private function createPluginAction(): void
+    public function createPluginAction(): void
     {
         if (file_exists('.git') || file_exists('.gitignore') || file_exists('facturascripts.ini')) {
             Utils::echo("* No se puede crear un plugin en esta carpeta.\n");

--- a/src/Console/ApplicationFS.php
+++ b/src/Console/ApplicationFS.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace fsmaker\Console;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\ListCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
+
+class ApplicationFS extends Application
+{
+    public function __construct(string $name = 'fsmaker', string $version = '1.9')
+    {
+        parent::__construct($name, $version);
+    }
+
+    protected function getDefaultInputDefinition(): InputDefinition
+    {
+        return new InputDefinition([
+            new InputArgument('command', InputArgument::REQUIRED, 'El comando a ejecutar'),
+//            new InputOption('--help', '-h', InputOption::VALUE_NONE, 'Display help for the given command. When no command is given display help for the <info>' . $this->defaultCommand . '</info> command'),
+//            new InputOption('--silent', null, InputOption::VALUE_NONE, 'Do not output any message'),
+//            new InputOption('--quiet', '-q', InputOption::VALUE_NONE, 'Only errors are displayed. All other output is suppressed'),
+//            new InputOption('--verbose', '-v|vv|vvv', InputOption::VALUE_NONE, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),
+//            new InputOption('--version', '-V', InputOption::VALUE_NONE, 'Display this application version'),
+//            new InputOption('--ansi', '', InputOption::VALUE_NEGATABLE, 'Force (or disable --no-ansi) ANSI output', null),
+//            new InputOption('--no-interaction', '-n', InputOption::VALUE_NONE, 'Do not ask any interactive question'),
+        ]);
+    }
+
+    protected function getDefaultCommands(): array
+    {
+        return [
+//            new HelpCommand(),
+            new ListCommand(),
+//            new CompleteCommand(),
+//            new DumpCompletionCommand()
+        ];
+    }
+}

--- a/src/Console/Command/PluginCommand.php
+++ b/src/Console/Command/PluginCommand.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace fsmaker\Console\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+
+require_once __DIR__ . '/../../../fsmaker.php';
+
+#[AsCommand(
+    name: 'plugin',
+    description: 'Crear un nuevo plugin'
+)]
+class PluginCommand extends Command
+{
+    public function __invoke(): void
+    {
+        new \fsmaker(['', 'plugin']);
+    }
+}


### PR DESCRIPTION
He subido de versión de php para que se pueda usar symfony/console. La versión de php no afecta al funcionamiento de los plugins así que podemos ir subiendo sin problema para poder usar nuevas características de php.

el cambiado a public el metodo `createPluginAction` para que se pueda acceder desde el comando de symfony.

he creado una clase ApplicationFS para poder quitar muchas opciones que vienen por defecto y que no nos van a servir inicialmente y solo ensucian la visualización de los comandos disponibles. lo dejo todo comentado para que veas lo que he quitado.

solo he creado el comando `plugin` para ver si te gusta la idea e ir añadiendo mas comandos o dejarlo para mas adelante.

<img width="490" height="277" alt="imagen" src="https://github.com/user-attachments/assets/706ed70d-a094-4440-8b91-28c041555180" />
