### PR TITLE
Corrige la creación de archivos ZIP en Windows

### DIFF
--- a/src/ZipGenerator.php
+++ b/src/ZipGenerator.php
@@ -44,6 +44,9 @@ class ZipGenerator
         );
 
         foreach ($files as $name => $file) {
+            // normalizamos el separador de rutas para Windows
+            $name = str_replace('\\', '/', $name);
+
             // excluimos archivos y carpetas ocultas
             if (substr($name, 0, 3) === './.') {
                 continue;
@@ -65,7 +68,7 @@ class ZipGenerator
             }
 
             // excluimos el propio zip
-            if ($name === $zipName) {
+            if ($name === './' . $zipName) {
                 continue;
             }
 


### PR DESCRIPTION
## Resumen
- Corrige ZipGenerator para normalizar los separadores de rutas en Windows
- En Windows, RecursiveDirectoryIterator devuelve barras invertidas que rompían la lógica de comparación de rutas
- Se agregó str_replace para normalizar las barras invertidas a barras antes del procesamiento
- También se corrigió la exclusión del archivo zip para usar el prefijo './' consistente con otras verificaciones