### PR TITLE
Añade soporte para .zipignore para excluir archivos del ZIP

### DIFF
--- a/src/ZipGenerator.php
+++ b/src/ZipGenerator.php
@@ -11,6 +11,79 @@ use ZipArchive;
 
 class ZipGenerator
 {
+    private static array $ignorePatterns = [];
+
+    private static function loadZipignore(): void
+    {
+        self::$ignorePatterns = [];
+
+        if (!file_exists('.zipignore')) {
+            return;
+        }
+
+        $lines = file('.zipignore', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if (empty($line) || $line[0] === '#') {
+                continue;
+            }
+            self::$ignorePatterns[] = $line;
+        }
+    }
+
+    private static function shouldIgnore(string $path): bool
+    {
+        $relativePath = ltrim($path, './\\');
+
+        foreach (self::$ignorePatterns as $pattern) {
+            $negated = $pattern[0] === '!';
+            if ($negated) {
+                $pattern = substr($pattern, 1);
+            }
+
+            $pattern = trim($pattern);
+            if (empty($pattern)) {
+                continue;
+            }
+
+            // Directorio: termina en /
+            $isDir = substr($pattern, -1) === '/';
+            if ($isDir) {
+                $pattern = rtrim($pattern, '/');
+            }
+
+            // Normalizar el patrón ./ -> vacío
+            $pattern = ltrim($pattern, './');
+
+            // Convertir glob a regex
+            $regex = self::globToRegex($pattern);
+
+            if ($isDir) {
+                // Para directorios, verificar si la ruta comienza con el patrón
+                $patternDir = ltrim($pattern, './');
+                if (strpos($relativePath, $patternDir . '/') === 0) {
+                    return !$negated;
+                }
+            } else {
+                $match = preg_match($regex, $relativePath);
+                if ($match) {
+                    return !$negated;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static function globToRegex(string $glob): string
+    {
+        $regex = preg_quote($glob, '/');
+        $regex = str_replace('\*\*', '.*', $regex);
+        $regex = str_replace('\*', '[^/]*', $regex);
+        $regex = str_replace('\?', '[^/]', $regex);
+        return '/^' . $regex . '$/';
+    }
+
     public static function generate(): void
     {
         if (false === Utils::isPluginFolder()) {
@@ -24,6 +97,8 @@ class ZipGenerator
             Utils::echo("* No se ha encontrado el nombre del plugin.\n");
             return;
         }
+
+        self::loadZipignore();
 
         $zipName = $pluginName . '.zip';
 
@@ -44,6 +119,9 @@ class ZipGenerator
         );
 
         foreach ($files as $name => $file) {
+            // normalizamos el separador de rutas para Windows
+            $name = str_replace('\\', '/', $name);
+
             // excluimos archivos y carpetas ocultas
             if (substr($name, 0, 3) === './.') {
                 continue;
@@ -65,7 +143,12 @@ class ZipGenerator
             }
 
             // excluimos el propio zip
-            if ($name === $zipName) {
+            if ($name === './' . $zipName) {
+                continue;
+            }
+
+            // aplicar reglas de .zipignore
+            if (self::shouldIgnore($name)) {
                 continue;
             }
 

--- a/src/ZipGenerator.php
+++ b/src/ZipGenerator.php
@@ -11,6 +11,79 @@ use ZipArchive;
 
 class ZipGenerator
 {
+    private static array $ignorePatterns = [];
+
+    private static function loadZipignore(): void
+    {
+        self::$ignorePatterns = [];
+
+        if (!file_exists('.zipignore')) {
+            return;
+        }
+
+        $lines = file('.zipignore', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if (empty($line) || $line[0] === '#') {
+                continue;
+            }
+            self::$ignorePatterns[] = $line;
+        }
+    }
+
+    private static function shouldIgnore(string $path): bool
+    {
+        $relativePath = ltrim($path, './\\');
+
+        foreach (self::$ignorePatterns as $pattern) {
+            $negated = $pattern[0] === '!';
+            if ($negated) {
+                $pattern = substr($pattern, 1);
+            }
+
+            $pattern = trim($pattern);
+            if (empty($pattern)) {
+                continue;
+            }
+
+            // Directorio: termina en /
+            $isDir = substr($pattern, -1) === '/';
+            if ($isDir) {
+                $pattern = rtrim($pattern, '/');
+            }
+
+            // Normalizar el patrón ./ -> vacío
+            $pattern = ltrim($pattern, './');
+
+            // Convertir glob a regex
+            $regex = self::globToRegex($pattern);
+
+            if ($isDir) {
+                // Para directorios, verificar si la ruta comienza con el patrón
+                $patternDir = ltrim($pattern, './');
+                if (strpos($relativePath, $patternDir . '/') === 0) {
+                    return !$negated;
+                }
+            } else {
+                $match = preg_match($regex, $relativePath);
+                if ($match) {
+                    return !$negated;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static function globToRegex(string $glob): string
+    {
+        $regex = preg_quote($glob, '/');
+        $regex = str_replace('\*\*', '.*', $regex);
+        $regex = str_replace('\*', '[^/]*', $regex);
+        $regex = str_replace('\?', '[^/]', $regex);
+        return '/^' . $regex . '$/';
+    }
+
     public static function generate(): void
     {
         if (false === Utils::isPluginFolder()) {
@@ -24,6 +97,8 @@ class ZipGenerator
             Utils::echo("* No se ha encontrado el nombre del plugin.\n");
             return;
         }
+
+        self::loadZipignore();
 
         $zipName = $pluginName . '.zip';
 
@@ -80,6 +155,11 @@ class ZipGenerator
 
             // excluimos el propio zip
             if ($name === './' . $zipName) {
+                continue;
+            }
+
+            // aplicar reglas de .zipignore
+            if (self::shouldIgnore($name)) {
                 continue;
             }
 


### PR DESCRIPTION
Muchas veces queremos que en el repositorio .git se guarden archivos de documentación, configuracion de herramientas de analisis estatico de codigo y archivos para el propio desarrollo del plugin pero no queremos que se agreguen al zip para distribuir al público. 

Aunque fsmaker ya ignora muchos archivos y carpetas no podemos adaptarlo a cada proyecto.

creando un archivo .zipignore podemos incluir estos archivos a excluir del zip.

por ejemplo, añadiendo:
doc/
al .zipignore se guardaría en github pero no en el zip de distribución.


## Resumen
- Añade soporte para archivo .zipignore en la raíz del plugin
- Implementa patrones similares a .gitignore:
  - * para comodín único
  - ** para múltiples directorios
  - ? para comodín simple
  - / al final para directorios
  - ! para negación
- Mantiene la compatibilidad con las exclusiones existentes (./Test/, archivos ocultos, Thumbs.db)