### PR TITLE
añadidas condiciones para evitar nulos

### DIFF
--- a/src/Command/Mod/ModCommand.php
+++ b/src/Command/Mod/ModCommand.php
@@ -85,9 +85,19 @@ class ModCommand extends BaseCommand
         // Escribir en Init.php
         $use = 'use ' . $useClass . ';';
         $newInitContent = InitEditor::addUse($use);
-        InitEditor::setInitContent($newInitContent);
+        if ($newInitContent !== null){
+            InitEditor::setInitContent($newInitContent);
+        }
+        else{
+            return Command::FAILURE;
+        }
         $newInitContent = InitEditor::addToInitFunction($initCode);
-        InitEditor::setInitContent($newInitContent);
+        if ($newInitContent !== null) {
+            InitEditor::setInitContent($newInitContent);
+        }
+        else {
+            return Command::FAILURE;
+        }
 
         return Command::SUCCESS;
     }


### PR DESCRIPTION
añadidas condiciones para evitar nulos en el comando mod ya que podía ocurrir que borrase el init.php