### PR TITLE
fix: indentación al insertar código en funciones vacías de Init.php

### DIFF
--- a/src/InitEditor.php
+++ b/src/InitEditor.php
@@ -111,6 +111,10 @@ class InitEditor
 
         // agregar indentation
         $indentation = self::getCurrentIndentation($body, mb_strlen($body) - 2);
+        if ($indentation === '') {
+            // función vacía: no hay línea previa de la que copiar la indentación
+            $indentation = $endIndents . '    ';
+        }
         $body .= self::formatTextWithIndentation($instructionStr, $indentation) . "\n" . $endIndents;
 
         return mb_substr($info['initContent'], 0, $info['functionStart']) . $body . mb_substr($info['initContent'], $info['functionEnd']);


### PR DESCRIPTION
## Bug
Al usar comandos que insertan código en `Init.php` (por ejemplo `fsmaker api`), si la función destino estaba vacía, las líneas se insertaban sin indentación (pegadas a la columna 0).

## Por qué sucede
`InitEditor::addToFunction()` copia la indentación de la última línea de código del cuerpo de la función. Si la función está vacía no hay ninguna línea de la que copiarla, y `getCurrentIndentation()` devuelve cadena vacía.

## Solución
Si la indentación calculada sale vacía, se usa como fallback la indentación de la llave de cierre más un nivel (4 espacios). Verificado con `fsmaker api` sobre un plugin de prueba y con la suite de tests en verde.