### PR TITLE
Bump version to 2.3.0

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -22,7 +22,7 @@ class Application extends BaseApplication
 {
     public function __construct()
     {
-        parent::__construct('fsmaker', '2.2.0');
+        parent::__construct('fsmaker', '2.3.0');
         $this->addCommands($this->getCommands());
     }
 


### PR DESCRIPTION
Se sube la versión a 2.3.0 para preparar la nueva release, que incluye soporte para .zipignore, comandos para workflows de GitHub Actions y otras mejoras y correcciones.

---

Texto para la release (copiar y pegar):

**Título:** fsmaker 2.3

**Descripción:**
> Esta nueva versión añade soporte para .zipignore, comandos para workflows de GitHub Actions y nuevas migraciones de métodos obsoletos.